### PR TITLE
initial fixes

### DIFF
--- a/ammo/ammo.json
+++ b/ammo/ammo.json
@@ -38,86 +38,87 @@
     "effects": [ "RECOVER_75" ]
   },
   {
-	"type": "AMMO",
-	"id": "throwing_knife_heavy",
-	"category": "weapons",
-	"price": 7500,
-	"name": "heavy throwing knife",
-	"name_plural": "heavy throwing knives",
-	"symbol": ";",
-	"color": "light_gray",
-	"description": "A more sturdy version of the simple throwing knife. The extra mass, sharpened point and balanced center of mass make for an excellent throwing utensil that should pack quite the punch.",
-	"material": "steel",
-	"volume": 1,
-	"weight": 550,
-	"bashing": 3,
-	"cutting": 12,
-	"thrown_damage": [
-		{"damage_type": "cut", "amount": 22 },
-		{"damage_type": "bash", "amount": 7 }
-	],
-	"ammo_type": "thrown",
-	"count": 5
+    "type": "AMMO",
+    "id": "throwing_knife_heavy",
+    "category": "weapons",
+    "price": 7500,
+    "name": "heavy throwing knife",
+    "name_plural": "heavy throwing knives",
+    "symbol": ";",
+    "color": "light_gray",
+    "description": "A more sturdy version of the simple throwing knife. The extra mass, sharpened point and balanced center of mass make for an excellent throwing utensil that should pack quite the punch.",
+    "material": "steel",
+    "volume": 2,
+    "weight": 550,
+    "bashing": 3,
+    "cutting": 12,
+    "thrown_damage": [
+        {"damage_type": "cut", "amount": 22 },
+        {"damage_type": "bash", "amount": 7 }
+    ],
+    "ammo_type": "thrown",
+    "count": 4
   },
   {
-	"type": "AMMO",
-	"id": "throwing_axe_heavy",
-	"category": "weapons",
-	"price": 15900,
-	"name": "heavy throwing axe",
-	"symbol": ";",
-	"color": "light_gray",
-	"description": "A somewhat heavy axe resembling a tomahawk. while the edges' form will not serve for any heavy-duty cutting work, the heavy and finely sharpened blade ought to cut quite deep.",
-	"material": ["steel", "wood"],
-	"volume": 3,
-	"weight": 1250,
-	"bashing": 6,
-	"cutting": 16,
-	"thrown_damage": [
-		{ "damage_type": "bash", "amount": 10 },
-		{ "damage_type": "cut", "amount": 28 }
-	],
-	"ammo_type": "thrown",
-	"count": 3
+    "type": "AMMO",
+    "id": "throwing_axe_heavy",
+    "category": "weapons",
+    "price": 15900,
+    "name": "heavy throwing axe",
+    "symbol": ";",
+    "color": "light_gray",
+    "description": "A somewhat heavy axe resembling a tomahawk. while the edges' form will not serve for any heavy-duty cutting work, the heavy and finely sharpened blade ought to cut quite deep.",
+    "material": ["steel", "wood"],
+    "volume": 4,
+    "weight": 1250,
+    "bashing": 6,
+    "cutting": 16,
+    "thrown_damage": [
+        { "damage_type": "bash", "amount": 18 },
+        { "damage_type": "cut", "amount": 16 }
+    ],
+    "ammo_type": "thrown",
+    "count": 3
   },
   {
-	"type": "AMMO",
-	"id": "shuriken",
-	"category": "weapons",
-	"price": 8900,
-	"name": "shuriken",
-	"symbol": "*",
-	"color": "light_gray",
-	"description": "lightweight throwing stars originating from Japan. While deadly in skilled hands, the shape and missing weight make for a difficult throw.",
-	"material": "steel",
-	"volume": 1,
-	"weight": 200,
-	"cutting": 8,
-	"thrown_damage": [
-		{"damage_type": "cut", "amount": 22}
-		],
-	"ammo_type": "thrown",
-	"count": 10
+    "type": "AMMO",
+    "id": "shuriken",
+    "category": "weapons",
+    "price": 8900,
+    "name": "shuriken",
+    "symbol": "*",
+    "color": "light_gray",
+    "description": "lightweight throwing stars originating from Japan. While deadly in skilled hands, the shape and missing weight make for a difficult throw.",
+    "material": "steel",
+    "volume": 1,
+    "weight": 200,
+    "cutting": 8,
+    "thrown_damage": [
+        {"damage_type": "cut", "amount": 22}
+        ],
+    "ammo_type": "thrown",
+    "count": 10
   },
   {
-	"type": "AMMO",
-	"id": "steel_dart",
-	"category": "weapons",
-	"price": 10000,
-	"name": "steel dart",
-	"name_plural": "steel darts",
-	"material": "steel",
-	"symbol": ";",
-	"color": "light_gray",
-	"description": "A common dart used for playing darts in bars and the likes. The notable exception is that the entire core as well as the point have been made out of steel, giving it extra weight and powerful penetration force.",
-	"volume": 1,
-	"weight": 350,
-	"to_hit": -1,
-	"cutting": 12,
-	"thrown_damage": [
-		{"damage_type": "stab", "amount": 25}
-	],
-	"ammo_type": "thrown",
-	"count": 3
+    "type": "AMMO",
+    "id": "steel_dart",
+    "category": "weapons",
+    "price": 10000,
+    "name": "steel dart",
+    "name_plural": "steel darts",
+    "material": "steel",
+    "symbol": ";",
+    "color": "light_gray",
+    "description": "A common dart used for playing darts in bars and the likes. The notable exception is that the entire core as well as the point have been made out of steel, giving it extra weight and powerful penetration force.",
+    "volume": 2,
+    "weight": 350,
+    "to_hit": -1,
+    "cutting": 12,
+    "thrown_damage": [
+        {"damage_type": "bash", "amount": 2},
+        {"damage_type": "stab", "amount": 23}
+    ],
+    "ammo_type": "thrown",
+    "count": 3
   }
 ]

--- a/recipes/recipes_weapon.json
+++ b/recipes/recipes_weapon.json
@@ -7,7 +7,7 @@
 	"skill_used": "fabrication",
 	"skills_required": ["throw", 2],
 	"difficulty": 6,
-	"time": 270000,
+	"time": 240000,
 	"autolearn": true,
 	"using": [
 		[ "forging_standard", 10 ],
@@ -93,7 +93,7 @@
 	"skill_used": "fabrication",
 	"skills_required": ["throw", 3],
 	"difficulty": 6,
-	"time": 60000,
+	"time": 360000,
 	"autolearn": true,
 	"using": [ 
 		[ "forging_standard", 10 ],


### PR DESCRIPTION
This PR adresses damage, weight, volume & crafting times only. Material requirements weren't checked at all.

**heavy knives:**
Volume 1 -> 2, craft stack 5 -> 4. Thus volume of a single knife went up from 0.05L to 0.13L. Reason for that - 2 times more mass than a regular knife implies more volume. And to balance a heavier blade we'd have to make a bigger handle. These knives still don't damage zombie soldiers but are really good against unarmored targets.

**heavy axes:**
Volume 3 -> 4 = 0.34 L per heavy axe, "bash=10, cut=28" -> "bash=18, cut=16"
Heavy axes should be balanced against steel lumps & throwing sticks since heavy axes have the worst range of all throwing weapons because of their weight. 
Lump of steel: bash=12, weight=1.00 kg allows to deal decent amount of damage to zombie soldiers which is pretty close to the damage from throwing sticks. Heavy axes have weight of 1.25 kg each and obviously should deal more bashing dmg just due to their weight. With a somewhat sharp piece of metal attached and a chance to hit the target with a handle we should get pretty broad dmg range. At least zombie soldiers do get more damage from the heavy axes than from steel lumps & throwing sticks now, and sometimes they get almost no damage, sometimes they get 15-18. More soft aka less armored targets get a nice amount of damage and the default range of 10 tiles doesn't make it OP.

**steel darts:**
Volume 1 -> 2 = 0.5 L for a batch of 3 darts, thus 1 dart would be 500/3 = 166 mL and twice as heavy as a regular dart of 250 mL volume. Also moved "2 dmg" to "bash" due to increased weight - 0.35 kg, steel chuck weights 0.25 kg for instance.

**shurikens:**
Original crafting time was 1 hour for 10 shurikens, 6 minutes for each one, smelting & sharpening included. Made it 30 minutes per shuriken. Not sure if we should increase the damage for them. Currently heavy knives offer the same CUT damage + 7 BASH dmg but they both obliterate soft targets on regular resilience settings. That could be adressed later on.